### PR TITLE
Bugfix link to lectures

### DIFF
--- a/app/Http/Controllers/LibraryController.php
+++ b/app/Http/Controllers/LibraryController.php
@@ -23,7 +23,7 @@ class LibraryController extends Controller {
     }
 
     public function lecture($index, $anchor = null){
-        return view('library.lectures.'.$index.$anchor);
+        return ($index != null) ? view('library.lectures.'.$index.$anchor) : view('library.index');
     }
 
     public function persons(){

--- a/app/Testing/Question.php
+++ b/app/Testing/Question.php
@@ -38,10 +38,13 @@ class Question extends Eloquent {
     protected $table = 'questions';
     public $timestamps = false;
 
+    const GROUP_AMOUNT = 3;         // TODO: think how it can be set outside
+
     /** Определяет одиночный вопрос (true) или может использоваться только в группе с такими же (false) */
-    public static function getSingle($id){
+    public static function isSingle($id){
         $type_code = Question::whereId_question($id)->select('type_code')->first()->type_code;
         $type = Type::whereType_code($type_code)->select('type_name')->first()->type_name;
+        // TODO: remove hard code of grouped question types
         if ($type == 'Да/Нет' || $type == 'Определение' || $type == 'Просто ответ'){
             return false;
         }

--- a/app/Testing/TestGeneration/DirectedEdge.php
+++ b/app/Testing/TestGeneration/DirectedEdge.php
@@ -98,7 +98,10 @@ class DirectedEdge {
         $types = [$this->node_to->type_code];
         switch ($this->type) {
             case EdgeType::BEGIN :
-                $this->capacity = Question::getAmount($sections, $themes, $types, $test_type, $printable);
+                $type = $types[0];
+                // TODO: remove hard code of grouped questions
+                $amount = Question::getAmount($sections, $themes, $types, $test_type, $printable);
+                $this->capacity = ($type == 5 || $type == 7) ? floor($amount / Question::GROUP_AMOUNT) : $amount;
                 break;
             case EdgeType::MIDDLE :
                 $this->capacity = $this->node_to->amount;

--- a/app/Testing/TestGeneration/UsualTestGenerator.php
+++ b/app/Testing/TestGeneration/UsualTestGenerator.php
@@ -14,8 +14,6 @@ use App\Testing\TestStructure;
  * Time: 23:38
  */
 class UsualTestGenerator implements TestGenerator {
-    const GROUP_AMOUNT = 3;
-
     /**
      * @var Graph
      */
@@ -160,7 +158,7 @@ class UsualTestGenerator implements TestGenerator {
                     $temp_array = Question::randomArray($temp_array);                                                       //выбираем случайный вопрос
                     $temp_question = $temp_array[count($temp_array)-1];
 
-                    if (Question::getSingle($temp_question)){                                                               //если вопрос одиночный (то есть как и было ранее)
+                    if (Question::isSingle($temp_question)){                                                               //если вопрос одиночный (то есть как и было ранее)
                         $array[$k] = $temp_question;                                                                        //добавляем вопрос в выходной массив
                         $k++;
                         $amount--;
@@ -182,7 +180,7 @@ class UsualTestGenerator implements TestGenerator {
                             }
                         }
 
-                        if (count($new_temp_array) < $this::GROUP_AMOUNT - 1){                                              // если нужных вопросов заведомо не хватит для составления группового вопроса
+                        if (count($new_temp_array) < Question::GROUP_AMOUNT - 1){                                              // если нужных вопросов заведомо не хватит для составления группового вопроса
                             foreach ($new_temp_array as $question_for_remove){                                              // удаляем их из temp_array
                                 $index_in_old_array = array_search($question_for_remove, $temp_array);                      //ищем в базовом массиве индекс нашего вопроса
                                 $chosen = $temp_array[$index_in_old_array];                                                 //и меняем его с последним элементом в этом массиве
@@ -194,7 +192,7 @@ class UsualTestGenerator implements TestGenerator {
                         }
 
                         $l = 1;
-                        while ($l < $this::GROUP_AMOUNT) {                                                                  //берем 3 вопроса
+                        while ($l < Question::GROUP_AMOUNT) {                                                                  //берем 3 вопроса
                             $new_temp_array = Question::randomArray($new_temp_array);
                             $temp_question_new = $new_temp_array[count($new_temp_array)-1];
 

--- a/config/database.php
+++ b/config/database.php
@@ -54,10 +54,10 @@ return [
 
         'mysql' => [
             'driver'    => 'mysql',
-            'host'      => 'localhost',
-            'database'  => 'uir',
-            'username'  => 'root',
-            'password'  => 'Tihomirova17Mephi',
+            'host'     => env('DB_HOST'),
+            'database' => env('DB_DATABASE'),
+            'username' => env('DB_USERNAME'),
+            'password' => env('DB_PASSWORD'),
             'charset'   => 'utf8',
             'collation' => 'utf8_unicode_ci',
             'prefix'    => '',

--- a/routes/web.php
+++ b/routes/web.php
@@ -99,7 +99,7 @@ Route::get('tests/groups-for-tests', ['as' => 'choose_group', 'uses' => 'TestCon
 Route::get('library', ['as' => 'library_index', 'uses' => 'LibraryController@index', 'middleware' => ['general_auth', 'access_for_library']]);
 Route::get('library/definitions', ['as' => 'library_definitions', 'uses' => 'LibraryController@definitions', 'middleware' => ['general_auth', 'access_for_library']]);
 Route::get('library/theorems', ['as' => 'library_theorems', 'uses' => 'LibraryController@theorems', 'middleware' => ['general_auth', 'admin', 'access_for_library']]);
-Route::get('library/lecture/{index}{anchor?}', ['as' => 'lecture', 'uses' => 'LibraryController@lecture', 'middleware' => ['general_auth', 'access_for_library']])->where('anchor', '[a-z0-9-]+');
+Route::get('library/lecture/{index?}{anchor?}', ['as' => 'lecture', 'uses' => 'LibraryController@lecture', 'middleware' => ['general_auth', 'access_for_library']])->where('anchor', '[a-z0-9-]+');
 Route::get('library/persons', ['as' => 'library_persons', 'uses' => 'LibraryController@persons', 'middleware' => ['general_auth', 'access_for_library']]);
 Route::get('library/persons/{person}', ['as' => 'person', 'uses' => 'LibraryController@person', 'middleware' => ['general_auth', 'access_for_library']]);
 Route::get('library/extra', ['as' => 'library_extra', 'uses' => 'LibraryController@extra', 'middleware' => ['general_auth', 'access_for_library']]);


### PR DESCRIPTION
- Bugfix: for grouped questions (yes/no) build link to the root of the library instead of concrete lecture, because grouped question doesn't have theme in database
- Process grouped question properly in test generator: devide amount of questions on GROUP_AMOUNT constant when evaluate edge capacity between source and record nodes
- Get database options from .env file. **ALERT! NEED TO UPDATE .ENV FILE ON SERVER BEFORE PULLING!**