### PR TITLE
Group creation bug fix with tests availability

### DIFF
--- a/app/Http/Controllers/AdministrationController.php
+++ b/app/Http/Controllers/AdministrationController.php
@@ -5,6 +5,8 @@ use App\Group;
 use App\Controls;
 use App\Lectures;
 use App\Seminars;
+use App\Testing\Test;
+use App\Testing\TestForGroup;
 use App\Totalresults;
 use App\Statements_progress;
 use App\TeacherHasGroup;
@@ -56,8 +58,14 @@ class AdministrationController extends Controller{
         $validate = Group::whereGroup_name($name)->get();
         if(count($validate) == 0){
             Group::insert(['group_name' => $name, 'description' => $description, 'archived' => 0]);
-            $id = Group::whereGroup_name($name)->get()->first();
-            Pass_plan::insert(['group' => $id['group_id']]);
+            $group_id = Group::whereGroup_name($name)->select('group_id')->first()->group_id;
+            Pass_plan::insert(['group' => $group_id]);
+
+            // add group availability for active tests
+            $active_tests = Test::whereArchived(0)->select('id_test')->get();
+            foreach ($active_tests as $test) {
+                TestForGroup::insert(['id_test' => $test['id_test'], 'id_group' => $group_id, 'availability' => 0]);
+            }
         }
         return redirect()->route('group_set');
     }


### PR DESCRIPTION
After new group creation add nil availability for active tests into test_for_group table 

for hot bug fix on prod (already executed):
```
INSERT INTO test_for_group (id_test, id_group, availability)
SELECT t.id_test, g.group_id, 0 FROM tests AS t, groups AS g 
WHERE t.archived = 0 and group_id IN (17, 20, 21, 22, 23, 24);
```
