### PR TITLE
Bug in drop test when id result wasn't initialized

### DIFF
--- a/app/Http/Controllers/TestController.php
+++ b/app/Http/Controllers/TestController.php
@@ -419,7 +419,7 @@ class TestController extends Controller{
         $left_min =  ($int_left_time > 0) ? floor($int_left_time/60) : 0;                                                                          //осталось минут
         $left_sec = ($int_left_time > 0) ? $int_left_time % 60 : 0;                                                                                //осталось секунд
 
-        $widgetListView = View::make('questions.student.widget_list',compact('current_result', 'amount', 'id_test','left_min', 'left_sec', 'test_type'))->with('widgets', $widgets);
+        $widgetListView = View::make('questions.student.widget_list',compact('amount', 'id_test','left_min', 'left_sec', 'test_type'))->with('widgets', $widgets);
         $response = new Response($widgetListView);
         return $response;
     }
@@ -498,10 +498,11 @@ class TestController extends Controller{
 
     /** Пользователь отказался от прохождения теста */
     public function dropTest(Request $request){
-        if (Result::getCurrentResult(Auth::user()['id'], $request->input('id_test') != -1)){
+        $current_result = Result::getCurrentResult(Auth::user()['id'], $request->input('id_test'));
+        if ($current_result != -1) {
             date_default_timezone_set('Europe/Moscow');
             $date = date('Y-m-d H:i:s', time());
-            Result::whereId_result($request->input('id_result'))->update(['result_date' => $date, 'result' => -1, 'mark_ru' => -1, 'mark_eu' => 'drop']);                                 //Присваиваем результату и оценке значения -1
+            Result::whereId_result($current_result)->update(['result_date' => $date, 'result' => -1, 'mark_ru' => -1, 'mark_eu' => 'drop']);                                 //Присваиваем результату и оценке значения -1
         }
         return redirect('tests');
     }

--- a/resources/views/questions/student/widget_list.blade.php
+++ b/resources/views/questions/student/widget_list.blade.php
@@ -36,7 +36,6 @@
 @for ($i = 0; $i < $amount; $i++)
 <input id="super{{$i}}" type="hidden" name="{{$i}}" value="">
 @endfor
-<input id="id-result" type="hidden" name="id_result" value="{{ $current_result }}">
 <input id="amount" type="hidden" name="amount" value="{{ $amount }}">
 <input type="hidden" name="id_test" value="{{ $id_test }}">
     <div class="col-sm-6">


### PR DESCRIPTION
Сценарий воспроизведения ошибки:
Начать новый тест
Уйти со страницы с тестом
Вновь перейти на страницу с тестом, пока время не закончилось
Отказаться от прохождения теста

в TestController#dropTest используется переменная $request->input('id_result'), которая не заполняется на странцие прохождения, если идет повторный вход. Больше эта переменная нигде не используется, поэтому от нее необходимо отказаться, а в dropTest поолучить id_result из Result#getCurrentResult